### PR TITLE
Fixed pip install failed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
```
$ pip install python-datemath
Collecting python-datemath
 Using cached python-datemath-1.3.tar.gz
   Complete output from command python setup.py egg_info:
   Traceback (most recent call last):

   FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/h2/fx8j3bps0657m2b9xvpcdjpr0000gn/T/pip-build-y5oysr_c/python-datemath/README.md'
```

README.md not found. 
