### PR TITLE
Fix expression progression logic and rounding

### DIFF
--- a/datemath/helpers.py
+++ b/datemath/helpers.py
@@ -168,23 +168,17 @@ def evaluate(expression, now, timeZone='UTC'):
     if debug: print('Expression: {0}'.format(expression))
     if debug: print('Now: {0}'.format(now))
     val = 0
-    for i, c in enumerate(expression):
+    i = 0
+    while i < len(expression):
         char = expression[i]
 
-        if i >= len(expression):
-            raise('Truncated datemath: {0}'.format(expression))
-
         if '/' in char:
-            # then we need to round up
+            # then we need to round
             next = str(expression[i+1])
-
-            roundUp = True            
+            i += 1
             now = roundDate(now, unitMap(next).rstrip('s'), timeZone)
 
         elif char == '+' or char == '-':
-            if i >= len(expression):
-                raise DateMathException('Truncated datemath: {0}'.format(expression))
-
             val = 0
 
             try:
@@ -202,7 +196,7 @@ def evaluate(expression, now, timeZone='UTC'):
         elif re.match('[a-zA-Z]+', char):
             now = calculate(now, val, unitMap(char))
         
-        i = i+1
+        i += 1
     if debug: print("Fin: {0}".format(now))
     if debug: print('\n\n')
     return now

--- a/tests.py
+++ b/tests.py
@@ -57,6 +57,10 @@ class TestDM(unittest.TestCase):
         self.assertEqual(dm('/M+2d').format(iso8601), arrow.utcnow().floor('month').replace(days=+2).format(iso8601))
         self.assertEqual(dm('now/w+2d-2h').format(iso8601), arrow.utcnow().floor('week').replace(days=+2, hours=-2).format(iso8601))
         self.assertEqual(dm('now/M+1w-2h+10s').format(iso8601), arrow.utcnow().floor('month').replace(weeks=+1, hours=-2, seconds=+10).format(iso8601))
+        self.assertEqual(dm('now-1d/d').format(iso8601), arrow.utcnow().replace(days=-1).floor('day').format(iso8601))
+        self.assertEqual(dm('now+1d/d').format(iso8601), arrow.utcnow().replace(days=1).floor('day').format(iso8601))
+        self.assertEqual(dm('now-10d/d').format(iso8601), arrow.utcnow().replace(days=-10).floor('day').format(iso8601))
+        self.assertEqual(dm('now+10d/d').format(iso8601), arrow.utcnow().replace(days=10).floor('day').format(iso8601))
         
 
         # future


### PR DESCRIPTION
The expression progression logic manipulated the variable `i` in two ways:
- direct manipulation in the body for the `for` loop
- via the `enumerate` function, which would reset the value `i` every loop
  iteration, overwriting whatever the body of the loop did to the value of
  `i`

This caused evaluation bugs where parts of the expression were evaluated twice:
```python
>>> datemath.dm('2016-12-28T10:00:00||-1d/d')
<Arrow [2016-12-26T00:00:00+00:00]>
```

The `for` loop is replaced with a `while` loop, and all changes to our position
in the expression buffer are now done explicitly in the body of the loop.