### PR TITLE
supporting round up and round down

### DIFF
--- a/datemath/helpers.py
+++ b/datemath/helpers.py
@@ -76,7 +76,7 @@ def as_datetime(expression, now, tz='UTC'):
     '''
     return parse(expression, now, tz)
 
-def parse(expression, now=None, tz='UTC', type=None):
+def parse(expression, now=None, tz='UTC', type=None, roundDown=True):
     '''
         the main meat and potatoes of this this whole thing
         takes our datemath expression and does our date math
@@ -123,7 +123,7 @@ def parse(expression, now=None, tz='UTC', type=None):
     if not math or math == '':
         rettime = time
 
-    rettime = evaluate(math, time, tz)
+    rettime = evaluate(math, time, tz, roundDown)
     if type:
         return getattr(rettime, type)
     else:
@@ -139,11 +139,14 @@ def parseTime(timestamp, tz='UTC'):
         return arrow.get(timestamp)
         
     
-def roundDate(now, unit, tz='UTC'):
+def roundDate(now, unit, tz='UTC', roundDown=True):
     '''
         rounds our date object
     '''
-    now = now.floor(unit)
+    if roundDown:
+        now = now.floor(unit)
+    else:
+        now = now.ceil(unit)
     if debug: print("roundDate Now: {0}".format(now))
     return now
 
@@ -161,7 +164,7 @@ def calculate(now, offsetval, unit):
     except Exception as e:
         raise DateMathException('Unable to calculate date: now: {0}, offsetvalue: {1}, unit: {2} - reason: {3}'.format(now,offsetval,unit,e))
 
-def evaluate(expression, now, timeZone='UTC'):
+def evaluate(expression, now, timeZone='UTC', roundDown=True):
     '''
         evaluates our datemath style expression
     '''
@@ -176,7 +179,7 @@ def evaluate(expression, now, timeZone='UTC'):
             # then we need to round
             next = str(expression[i+1])
             i += 1
-            now = roundDate(now, unitMap(next).rstrip('s'), timeZone)
+            now = roundDate(now, unitMap(next).rstrip('s'), timeZone, roundDown)
 
         elif char == '+' or char == '-':
             val = 0

--- a/tests.py
+++ b/tests.py
@@ -23,6 +23,10 @@ class TestDM(unittest.TestCase):
         self.assertEqual(dm('2016-01-02T14:02:00||/h').format(iso8601), '2016-01-02T14:00:00-00:00')
         self.assertEqual(dm('2016-01-02T14:02:00||/H').format(iso8601), '2016-01-02T14:00:00-00:00')
 
+        # Rounding Up Tests
+        self.assertEqual(dm('2016-01-01||/d', roundDown=False).format('YYYY-MM-DDTHH:mm:ssZZ'), '2016-01-01T23:59:59-00:00')
+        self.assertEqual(dm('2014-11-18||/y', roundDown=False).format('YYYY-MM-DDTHH:mm:ssZZ'), '2014-12-31T23:59:59-00:00')
+
         # relitive formats
         # addition
         self.assertEqual(dm('+1s').format(iso8601), arrow.utcnow().replace(seconds=+1).format(iso8601))
@@ -51,6 +55,15 @@ class TestDM(unittest.TestCase):
         self.assertEqual(dm('/M').format(iso8601), arrow.utcnow().floor('month').format(iso8601))
         self.assertEqual(dm('/Y').format(iso8601), arrow.utcnow().floor('year').format(iso8601))
         self.assertEqual(dm('/y').format(iso8601), arrow.utcnow().floor('year').format(iso8601))
+        # rounding up
+        self.assertEqual(dm('/s', roundDown=False).format(iso8601), arrow.utcnow().ceil('second').format(iso8601))
+        self.assertEqual(dm('/m', roundDown=False).format(iso8601), arrow.utcnow().ceil('minute').format(iso8601))
+        self.assertEqual(dm('/h', roundDown=False).format(iso8601), arrow.utcnow().ceil('hour').format(iso8601))
+        self.assertEqual(dm('/d', roundDown=False).format(iso8601), arrow.utcnow().ceil('day').format(iso8601))
+        self.assertEqual(dm('/w', roundDown=False).format(iso8601), arrow.utcnow().ceil('week').format(iso8601))
+        self.assertEqual(dm('/M', roundDown=False).format(iso8601), arrow.utcnow().ceil('month').format(iso8601))
+        self.assertEqual(dm('/Y', roundDown=False).format(iso8601), arrow.utcnow().ceil('year').format(iso8601))
+        self.assertEqual(dm('/y', roundDown=False).format(iso8601), arrow.utcnow().ceil('year').format(iso8601))
         # complicated date math
         self.assertEqual(dm('now/d-1h').format(iso8601), arrow.utcnow().floor('day').replace(hours=-1).format(iso8601))
         self.assertEqual(dm('+1h').format(iso8601), arrow.utcnow().replace(hours=+1).format(iso8601))


### PR DESCRIPTION
For example, the expression `from: "now/d", until: "now/d"` in ElasticSearch
will be translate into starts from 00:00:00 and ends at 23:59:59. There is
not way to distinguish these two case, so add another argument `roundDown` to
specified the method when rounding date, default value is True, which means 'floor'.