### PR TITLE
Inherit from Exception rather than BaseException

### DIFF
--- a/datemath/helpers.py
+++ b/datemath/helpers.py
@@ -46,7 +46,7 @@ import sys
 
 debug = True if os.environ.get('DEBUG') == 'true' else False 
 
-class DateMathException(BaseException):
+class DateMathException(Exception):
     pass 
 
 def unitMap(c):


### PR DESCRIPTION
Python docs say custom exceptions should not derive from `BaseException`.

https://docs.python.org/3/library/exceptions.html