### PR TITLE
Fix `SyntaxWarning: invalid escape sequence`

### DIFF
--- a/datemath/helpers.py
+++ b/datemath/helpers.py
@@ -111,7 +111,7 @@ def parse(expression, now=None, tz='UTC', type=None, roundDown=True):
             return getattr(now, type)
         else:
             return now
-    elif re.match('\d{10,}', str(expression)):
+    elif re.match(r'\d{10,}', str(expression)):
         if debug: print('parse() - found an epoch timestamp')
         if len(str(expression)) == 13:
             raise DateMathException('Unable to parse epoch timestamps in millis, please convert to the nearest second to continue - i.e. 1451610061 / 1000')
@@ -225,7 +225,7 @@ def evaluate(expression, now, timeZone='UTC', roundDown=True):
             val = 0
 
             try:
-                m = re.match('(\d*[.]?\d+)[\w+-/]', expression[i+1:])
+                m = re.match(r'(\d*[.]?\d+)[\w+-/]', expression[i+1:])
                 if m:
                     num = m.group(1)
                     val = val * 10 + float(num)


### PR DESCRIPTION
With python 3.12 the `DeprecationWarning` for invalid escape sequence has been upgraded to a `SyntaxWarning`, see [python 3.12 documentation here](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes)

I've just converted these to raw strings to resolve the problem.