### PR TITLE
fix: rename requirements-3.txt to requirements.txt in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 
 source env/bin/activate
 pip2.7 install -r requirements-2.txt
-pip3.7 install -r requirements-3.txt
+pip3.7 install -r requirements.txt
 
 echo "Removing any previous build dir..."
 rm -rf build


### PR DESCRIPTION
I just came across this while looking into the repository. It looks like requirements-3.txt was renamed as requirements.txt but not in build.sh. Please feel free to merge this or not.